### PR TITLE
Fix navigation and remove saving state on nav graph.

### DIFF
--- a/app/src/main/java/com/jonnesten/lullanap/bottomnav/BottomNavActivity.kt
+++ b/app/src/main/java/com/jonnesten/lullanap/bottomnav/BottomNavActivity.kt
@@ -40,14 +40,8 @@ fun BottomNavigation(navController: NavController) {
                 selected = currentRoute == item.screen_route,
                 onClick = {
                     navController.navigate(item.screen_route) {
-
-                        navController.graph.startDestinationRoute?.let { screen_route ->
-                            popUpTo(screen_route) {
-                                saveState = true
-                            }
-                        }
+                        popUpTo(navController.graph.startDestinationId)
                         launchSingleTop = true
-                        restoreState = true
                     }
                 }
             )


### PR DESCRIPTION
fixes #12
### Problem
When pressin Scan on the `HomeScreen` the navigation will break and user cannot access to home page anymore.

### Cause
`BottomNavigationItem` saves the states in the nav graph and because pages `Scanning` & `Results` are not part of `BottomNavigationBar` the nav graph does not have route in back stack,

### Solution
When `BottomNavigationItem` is clicked, the `navController` needs to provide navigation graph start destination route usins `popUpTo()`. Also `saveState` and `restoreState` are no longer needed.

### Behavioural changes
When user press `back` in the `Android Bottom Navigation`:
  - Once: User is redirected to the HomeScreen (also known as the start destination).
  - Twice: Application closes.